### PR TITLE
Strip {ID:N} prefix from Translate action results before SetTarget

### DIFF
--- a/Apps.GoogleVertexAI/Actions/TranslationActions.cs
+++ b/Apps.GoogleVertexAI/Actions/TranslationActions.cs
@@ -98,8 +98,6 @@ public class TranslationActions(InvocationContext invocationContext, IFileManage
                         "Try to reduce the batch size.");
                 }
 
-                // Strip the {ID:N} prefix Gemini was asked to preserve, so it doesn't
-                // land in segment.SetTarget(...). Mirrors BatchActions/EditActions.
                 return result.Results.Select(s => s is null ? null : Regex.Replace(s, @"^\{ID:\d+\}", ""));
             }
             catch (PluginApplicationException ex)

--- a/Apps.GoogleVertexAI/Actions/TranslationActions.cs
+++ b/Apps.GoogleVertexAI/Actions/TranslationActions.cs
@@ -98,7 +98,9 @@ public class TranslationActions(InvocationContext invocationContext, IFileManage
                         "Try to reduce the batch size.");
                 }
 
-                return result.Results;
+                // Strip the {ID:N} prefix Gemini was asked to preserve, so it doesn't
+                // land in segment.SetTarget(...). Mirrors BatchActions/EditActions.
+                return result.Results.Select(s => s is null ? null : Regex.Replace(s, @"^\{ID:\d+\}", ""));
             }
             catch (PluginApplicationException ex)
             {


### PR DESCRIPTION
`BatchTranslate` in `Apps.GoogleVertexAI/Actions/TranslationActions.cs` prepends each segment with a `{ID:N}` marker so that Gemini preserves an index that can be reconciled on parse. The strip step that should remove the marker after parsing is missing — the marker is written verbatim into `segment.SetTarget(translation)` and persists into the published target content (where it ends up visible to end users). We can see that `BatchActions.cs` (~line 120) and `EditActions.cs` (~line 80) already strip their (differently-formatted) markers via similar regex.

## Reproduction

Verified against `gemini-3.1-flash-lite-preview` using a Python harness that ports `prompts.py` and `GeminiResponseParser.cs`:

| Content | Locales | Before | After |
|---|---|---|---|
| 3 newss entries | de, pt-BR, ja | every parsed segment starts with `{ID:N}` (13/13 segments × 3 locales = 39/39 leaked) | 0/39 leaked |

Sample (German title, segment 0):

- Before: `{ID:0}Daten: Der gesamte Nettozufluss bei Bitcoin-Spot-ETFs...`
- After: `Daten: Der gesamte Nettozufluss bei Bitcoin-Spot-ETFs...`

Raw Gemini response still contains the markers (expected — the prompt asks for them); the strip happens between parse and `SetTarget`.